### PR TITLE
Fix screenshot workflow dependencies

### DIFF
--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -1,0 +1,36 @@
+name: screenshot
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  capture:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+      - name: Build project
+        run: npm run build
+      - name: Install screenshot tools
+        run: npm install --no-save playwright http-server
+      - name: Install browsers
+        run: npx playwright install --with-deps
+      - name: Take screenshot
+        run: npm run screenshot
+      - name: Upload screenshot
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr-screenshot
+          path: pr-screenshot.png
+      - name: Comment link
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          message: |
+            :camera: [Download screenshot](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build && next export && next-image-export-optimizer",
     "start": "next start",
     "lint": "next lint",
-    "format": "prettier -w --write ."
+    "format": "prettier -w --write .",
+    "screenshot": "node scripts/screenshot.js"
   },
   "dependencies": {
     "firebase": "9.23.0",

--- a/scripts/screenshot.js
+++ b/scripts/screenshot.js
@@ -1,0 +1,17 @@
+const httpServer = require("http-server");
+const { chromium } = require("playwright");
+const path = require("path");
+
+const outDir = path.join(__dirname, "..", "out");
+const output = path.join(__dirname, "..", "pr-screenshot.png");
+
+const server = httpServer.createServer({ root: outDir });
+
+server.listen(3000, async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto("http://localhost:3000");
+  await page.screenshot({ path: output, fullPage: true });
+  await browser.close();
+  server.close();
+});


### PR DESCRIPTION
## Summary
- install Playwright and http-server in CI instead of storing them in devDependencies
- run screenshot workflow on `ubuntu-22.04`

## Testing
- `npm run lint`
- `npm run build`
