### PR TITLE
Fix ESLint parsing by switching to Babel parser

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,18 @@
+module.exports = {
+  extends: "next/core-web-vitals",
+  overrides: [
+    {
+      files: ["**/*.ts?(x)"],
+      parser: require.resolve("next/dist/compiled/babel/eslint-parser"),
+      parserOptions: {
+        requireConfigFile: false,
+        babelOptions: {
+          presets: [require.resolve("next/babel")],
+        },
+      },
+    },
+  ],
+  rules: {
+    "@next/next/no-img-element": "off",
+  },
+};

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "next/core-web-vitals",
-  "rules": {
-    "@next/next/no-img-element": "off"
-  }
-}


### PR DESCRIPTION
## Summary
- use a JS-based ESLint config
- configure ESLint to parse TypeScript using the bundled Babel parser

## Testing
- `npm run lint`
- `npm run format`