### PR TITLE
Modernize color palette

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -12,7 +12,7 @@ const _year = new Date().getFullYear();
     <link rel="icon" href="/favicon.ico" />
   </head>
   <body>
-    <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-950 text-slate-200">
+    <div class="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-indigo-900 via-purple-900 to-slate-950 text-slate-200">
       <main class="container px-4 py-8">
         <About />
       </main>

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -1,6 +1,6 @@
 .container {
   padding: 0 2rem;
-  background-color: rgb(31 41 55);
+  background-color: rgb(30 41 59);
 }
 
 .main {
@@ -30,7 +30,7 @@
 }
 
 .title a {
-  color: #0070f3;
+  color: #6366f1;
   text-decoration: none;
 }
 
@@ -96,8 +96,8 @@
 .card:hover,
 .card:focus,
 .card:active {
-  color: #0070f3;
-  border-color: #0070f3;
+  color: #6366f1;
+  border-color: #6366f1;
 }
 
 .card h2 {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -18,8 +18,8 @@ body {
     Fira Sans,
     Helvetica Neue,
     sans-serif;
-  color: rgb(226 232 240);
-  background: linear-gradient(to bottom right, #1e293b, #0f172a);
+  color: rgb(241 245 249);
+  background: linear-gradient(to bottom right, #1e40af, #9333ea, #0f172a);
 }
 
 a {


### PR DESCRIPTION
## Summary
- use a deeper indigo-to-purple gradient
- tweak default text color
- adjust accent colors in Home page styles

## Testing
- `npm run format`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_684134e7375083289b36e5156cca9e6b