### PR TITLE
fix: GitHub PagesでSPAルーティングが機能するように修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,17 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      // Handle redirect from 404.html for GitHub Pages SPA
+      (function() {
+        const redirect = new URLSearchParams(window.location.search).get('redirect');
+        if (redirect) {
+          // Remove the redirect query parameter and navigate to the actual path
+          const url = decodeURIComponent(redirect);
+          window.history.replaceState(null, '', '/' + url);
+        }
+      })();
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>tkt - Web Application Developer</title>
+    <meta name="description" content="Hi, I'm tkt. I'm a web application developer from Japan." />
+    <link rel="icon" href="/favicon.ico" />
+    <script>
+      // GitHub Pages SPA redirect workaround
+      const pathSegmentsToKeep = 0;
+      const path = window.location.pathname;
+      const search = window.location.search;
+      const hash = window.location.hash;
+      
+      // Redirect to index.html with the path as a query parameter
+      window.location.replace(
+        window.location.protocol + '//' + 
+        window.location.hostname + 
+        (window.location.port ? ':' + window.location.port : '') +
+        path.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/' +
+        '?redirect=' + encodeURIComponent(path.slice(1) + search + hash)
+      );
+    </script>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- GitHub Pagesで直接URLアクセス時の404エラーを修正
- 404.htmlを使用したリダイレクトハックを実装
- すべてのルートで正しくReact Routerが動作するように改善

## Test plan
- [ ] ビルドが成功することを確認
- [ ] デプロイ後、ルートURL（/）へのアクセスが正常に動作すること
- [ ] デプロイ後、直接URL（例：/resume）へのアクセスが正常に動作すること
- [ ] ブラウザの戻る/進むボタンが正常に動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)