### PR TITLE
fix: GitHub Pages deployment configuration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,13 +4,25 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -22,9 +34,29 @@ jobs:
       - name: build
         run: docker compose run --rm app /bin/bash -c "npm i && npm run build"
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          cname: tktcorporation.com
-          publish_dir: ./dist
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
+      
+      - name: Show deployment URL
+        shell: bash
+        run: |
+          echo "🎉 Deployment completed!"
+          echo "🌐 Your site is available at: ${{ steps.deployment.outputs.page_url }}"
+          echo ""
+          echo "📊 Calendar data URL: ${{ steps.deployment.outputs.page_url }}calendar-data.json"

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+tktcorporation.com

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,0 +1,1 @@
+tktcorporation.com

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,22 @@
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
+import { copyFileSync } from "fs";
+import { resolve } from "path";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    {
+      name: "copy-404",
+      closeBundle() {
+        // Copy 404.html to dist after build
+        copyFileSync(
+          resolve(__dirname, "public/404.html"),
+          resolve(__dirname, "dist/404.html"),
+        );
+      },
+    },
+  ],
   server: {
     host: "0.0.0.0",
   },


### PR DESCRIPTION
## Summary
- GitHub Actions を使用した GitHub Pages デプロイに切り替え
- カスタムドメイン (tktcorporation.com) のサポートを追加
- SPA ルーティング用の 404.html 処理を改善

## Changes
- 🔧 Deploy workflow を GitHub Pages Actions (`actions/deploy-pages`) に更新
- 📝 CNAME ファイルをカスタムドメイン用に追加
- ⚙️ Vite 設定を更新して 404.html を自動コピー
- 📊 デプロイ完了時に URL を表示

## Test plan
- [x] ビルドが正常に完了することを確認
- [ ] GitHub Pages へのデプロイが成功することを確認
- [ ] カスタムドメインでサイトにアクセスできることを確認
- [ ] SPA ルーティングが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)