### PR TITLE
feat: resume ページへのリンクをホームページから削除

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -17,14 +15,14 @@
         "useExhaustiveDependencies": "warn"
       },
       "style": {
-        "noVar": "error",
         "useConst": "error",
         "useTemplate": "error"
       },
       "suspicious": {
         "noExplicitAny": "warn",
         "noDuplicateFontNames": "off",
-        "noArrayIndexKey": "off"
+        "noArrayIndexKey": "off",
+        "noVar": "error"
       }
     }
   },
@@ -56,11 +54,19 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".astro", ".next", "build", "coverage"]
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/.astro",
+      "!**/.next",
+      "!**/build",
+      "!**/coverage"
+    ]
   },
   "overrides": [
     {
-      "include": ["**/*.astro"],
+      "includes": ["**/*.astro"],
       "linter": {
         "rules": {
           "correctness": {

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import httpServer from "http-server";
-import { type Browser, type Page, chromium } from "playwright";
+import { type Browser, chromium, type Page } from "playwright";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/test-display.ts
+++ b/scripts/test-display.ts
@@ -1,4 +1,4 @@
-import { type Browser, type Page, chromium } from "playwright";
+import { type Browser, chromium, type Page } from "playwright";
 
 const testDisplay = async (): Promise<void> => {
   let browser: Browser | null = null;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 import { type FirebaseApp, getApps, initializeApp } from "firebase/app";
 import "firebase/analytics";
 import { type Analytics, getAnalytics } from "firebase/analytics";
+
 const FIREBASE_APIKEY = "AIzaSyDCMz60fSZWmUamvWoiCm3qnMwWnqo0Ld8";
 
 const firebaseConfig = {

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,3 @@
-import { Link } from "react-router-dom";
-
 const socialLinks = [
   {
     href: "https://lapras.com/public/tktcorporation",
@@ -56,17 +54,6 @@ const socialLinks = [
 function Home() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-indigo-900 via-purple-900 to-slate-950 text-slate-200">
-      <nav className="absolute top-0 left-0 right-0 p-6">
-        <div className="container mx-auto flex justify-end gap-6">
-          <Link
-            to="/resume"
-            className="px-6 py-2 bg-purple-600/20 hover:bg-purple-600/30 border border-purple-500/30 rounded-lg transition-all duration-300 hover:scale-105"
-          >
-            Resume
-          </Link>
-        </div>
-      </nav>
-
       <main className="container px-4 py-8">
         <div>
           <h1 className="text-6xl font-bold text-white">Hi 👋, I'm tkt.</h1>

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -89,7 +89,9 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
   max-width: 300px;
 }
 


### PR DESCRIPTION
Closes #621

## 変更内容
- ホームページのナビゲーション部分からresumeリンクを削除
- `/resume`への直接アクセスは引き続き可能
- 不要なLink importも削除
- biome.jsonを新バージョンに移行
- リンターで発見された軽微な問題を修正

Generated with [Claude Code](https://claude.ai/code)