### PR TITLE
chore(deps): update dev dependencies to latest stable versions

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,8 +1,6 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
-  "organizeImports": {
-    "enabled": true
-  },
+  "$schema": "https://biomejs.dev/schemas/2.1.4/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
@@ -17,14 +15,14 @@
         "useExhaustiveDependencies": "warn"
       },
       "style": {
-        "noVar": "error",
         "useConst": "error",
         "useTemplate": "error"
       },
       "suspicious": {
         "noExplicitAny": "warn",
         "noDuplicateFontNames": "off",
-        "noArrayIndexKey": "off"
+        "noArrayIndexKey": "off",
+        "noVar": "error"
       }
     }
   },
@@ -56,11 +54,19 @@
     }
   },
   "files": {
-    "ignore": ["node_modules", "dist", ".astro", ".next", "build", "coverage"]
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/dist",
+      "!**/.astro",
+      "!**/.next",
+      "!**/build",
+      "!**/coverage"
+    ]
   },
   "overrides": [
     {
-      "include": ["**/*.astro"],
+      "includes": ["**/*.astro"],
       "linter": {
         "rules": {
           "correctness": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,14 +21,14 @@
         "@biomejs/biome": "^2.1.4",
         "@tktco/node-actionlint": "^1.6.0",
         "@types/http-server": "^0.12.4",
-        "@types/node": "20.9.1",
+        "@types/node": "24.2.1",
         "autoprefixer": "10.4.21",
         "http-server": "^14.1.1",
-        "playwright": "^1.53.2",
+        "playwright": "^1.54.2",
         "postcss": "8.5.6",
         "tailwindcss": "3.4.17",
         "tsx": "^4.20.3",
-        "typescript": "5.8.3",
+        "typescript": "5.9.2",
         "vite": "^5.4.11"
       },
       "engines": {
@@ -2173,12 +2173,12 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.9.1.tgz",
-      "integrity": "sha512-HhmzZh5LSJNS5O8jQKpJ/3ZcrrlG6L70hpGqMIAoM9YVD0YBRNWYsfwcXq8VnSjlNpCpgLzMXdiPo+dxcvSmiA==",
+      "version": "24.2.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.2.1.tgz",
+      "integrity": "sha512-DRh5K+ka5eJic8CjH7td8QpYEV6Zo10gfRkjHCO3weqZHWDtAaSTFtl4+VMqOJ4N5jcuhZ9/l+yy8rVgw7BQeQ==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.10.0"
       }
     },
     "node_modules/@types/react": {
@@ -3687,12 +3687,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.53.2.tgz",
-      "integrity": "sha512-6K/qQxVFuVQhRQhFsVZ9fGeatxirtrpPgxzBYWyZLEXJzqYwuL4fuNmfOfD5et1tJE4GScKyPNeLhZeRwuTU3A==",
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.53.2"
+        "playwright-core": "1.54.2"
       },
       "bin": {
         "playwright": "cli.js"
@@ -3705,10 +3706,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.53.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.53.2.tgz",
-      "integrity": "sha512-ox/OytMy+2w1jcYEYlOo1Hhp8hZkLCximMTUTMBXjGUA1KoFfiSZ+DU+3a739jsPY0yoKH2TFy9S2fsJas8yAw==",
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -4603,9 +4605,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4617,9 +4619,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
+      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
       "license": "MIT"
     },
     "node_modules/union": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "@biomejs/biome": "^2.1.4",
     "@tktco/node-actionlint": "^1.6.0",
     "@types/http-server": "^0.12.4",
-    "@types/node": "20.9.1",
+    "@types/node": "24.2.1",
     "autoprefixer": "10.4.21",
     "http-server": "^14.1.1",
-    "playwright": "^1.53.2",
+    "playwright": "^1.54.2",
     "postcss": "8.5.6",
     "tailwindcss": "3.4.17",
     "tsx": "^4.20.3",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "^5.4.11"
   },
   "engines": {

--- a/scripts/screenshot.ts
+++ b/scripts/screenshot.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import httpServer from "http-server";
-import { type Browser, type Page, chromium } from "playwright";
+import { type Browser, chromium, type Page } from "playwright";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/scripts/test-display.ts
+++ b/scripts/test-display.ts
@@ -1,4 +1,4 @@
-import { type Browser, type Page, chromium } from "playwright";
+import { type Browser, chromium, type Page } from "playwright";
 
 const testDisplay = async (): Promise<void> => {
   let browser: Browser | null = null;

--- a/src/firebase.ts
+++ b/src/firebase.ts
@@ -1,6 +1,7 @@
 import { type FirebaseApp, getApps, initializeApp } from "firebase/app";
 import "firebase/analytics";
 import { type Analytics, getAnalytics } from "firebase/analytics";
+
 const FIREBASE_APIKEY = "AIzaSyDCMz60fSZWmUamvWoiCm3qnMwWnqo0Ld8";
 
 const firebaseConfig = {

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import experiencesData from "../data/experiences.json";
 
@@ -28,21 +28,7 @@ function Resume() {
   const [skills, setSkills] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const sortedExperiences = [...experiencesData.experience_list].sort(
-      (a, b) => {
-        const aDate = a.start_year * 12 + a.start_month;
-        const bDate = b.start_year * 12 + b.start_month;
-        return bDate - aDate;
-      }
-    );
-
-    setExperiences(sortedExperiences);
-    setSkills(extractSkills(sortedExperiences));
-    setLoading(false);
-  }, []);
-
-  const extractSkills = (exps: Experience[]): string[] => {
+  const extractSkills = useCallback((exps: Experience[]): string[] => {
     const skillSet = new Set<string>();
     const techRegex =
       /\b(AWS|Docker|Python|Django|TypeScript|Vue|React|Node\.js|JavaScript|Kotlin|Android|iOS|Swift|Java|Crystal|NestJS|MySQL|PostgreSQL|DynamoDB|Redis|MongoDB|Elasticsearch|BigQuery|Lambda|S3|CloudFormation|CloudFront|Route53|ECR|ECS|CircleCI|GitHub Actions|GitLab|Bitbucket|Selenium|Terraform|Kubernetes|Firebase|Figma|Jira|Vite|Tailwind CSS)\b/gi;
@@ -59,7 +45,21 @@ function Resume() {
     }
 
     return Array.from(skillSet);
-  };
+  }, []);
+
+  useEffect(() => {
+    const sortedExperiences = [...experiencesData.experience_list].sort(
+      (a, b) => {
+        const aDate = a.start_year * 12 + a.start_month;
+        const bDate = b.start_year * 12 + b.start_month;
+        return bDate - aDate;
+      }
+    );
+
+    setExperiences(sortedExperiences);
+    setSkills(extractSkills(sortedExperiences));
+    setLoading(false);
+  }, [extractSkills]);
 
   const formatDate = (
     year: number,

--- a/src/styles/Home.module.css
+++ b/src/styles/Home.module.css
@@ -89,7 +89,9 @@
   text-decoration: none;
   border: 1px solid #eaeaea;
   border-radius: 10px;
-  transition: color 0.15s ease, border-color 0.15s ease;
+  transition:
+    color 0.15s ease,
+    border-color 0.15s ease;
   max-width: 300px;
 }
 


### PR DESCRIPTION
Update critical dev dependencies to their latest stable versions:

- @types/node: 20.9.1 → 24.2.1 (Node.js 24 support)
- TypeScript: 5.8.3 → 5.9.2 (latest stable with bug fixes)
- Playwright: 1.53.2 → 1.54.2 (codegen and proxy fixes)
- Biome: 1.9.4 → 2.1.4 (auto-migrated config)

All updates tested with successful builds, linting, and type checks.

Tailwind CSS v4 upgrade intentionally deferred due to breaking changes.

Generated with [Claude Code](https://claude.ai/code)