### PR TITLE
全体的にフォントサイズを小さくして見やすく調整

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -56,12 +56,12 @@ function Home() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-gradient-to-br from-indigo-900 via-purple-900 to-slate-950 text-slate-200">
       <main className="container px-4 py-8">
         <div>
-          <h1 className="text-6xl font-bold text-white">Hi 👋, I'm tkt.</h1>
-          <h3 className="text-3xl mt-16 text-slate-300">
+          <h1 className="text-4xl font-bold text-white">Hi 👋, I'm tkt.</h1>
+          <h3 className="text-xl mt-16 text-slate-300">
             I'm a web application developer from Japan.
           </h3>
 
-          <h3 className="text-3xl mt-16 text-slate-200">Connect with me:</h3>
+          <h3 className="text-xl mt-16 text-slate-200">Connect with me:</h3>
 
           <div className="flex flex-row mt-8 flex-wrap">
             {socialLinks.map((link) => (
@@ -87,7 +87,7 @@ function Home() {
             ))}
           </div>
 
-          <h3 className="text-3xl mt-16 text-slate-200">Support:</h3>
+          <h3 className="text-xl mt-16 text-slate-200">Support:</h3>
           <div className="mt-8">
             <a
               href="https://www.buymeacoffee.com/tktcorporation"

--- a/src/pages/Resume.tsx
+++ b/src/pages/Resume.tsx
@@ -1,5 +1,5 @@
 import type React from "react";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link } from "react-router-dom";
 import experiencesData from "../data/experiences.json";
 
@@ -28,21 +28,7 @@ function Resume() {
   const [skills, setSkills] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const sortedExperiences = [...experiencesData.experience_list].sort(
-      (a, b) => {
-        const aDate = a.start_year * 12 + a.start_month;
-        const bDate = b.start_year * 12 + b.start_month;
-        return bDate - aDate;
-      }
-    );
-
-    setExperiences(sortedExperiences);
-    setSkills(extractSkills(sortedExperiences));
-    setLoading(false);
-  }, []);
-
-  const extractSkills = (exps: Experience[]): string[] => {
+  const extractSkills = useCallback((exps: Experience[]): string[] => {
     const skillSet = new Set<string>();
     const techRegex =
       /\b(AWS|Docker|Python|Django|TypeScript|Vue|React|Node\.js|JavaScript|Kotlin|Android|iOS|Swift|Java|Crystal|NestJS|MySQL|PostgreSQL|DynamoDB|Redis|MongoDB|Elasticsearch|BigQuery|Lambda|S3|CloudFormation|CloudFront|Route53|ECR|ECS|CircleCI|GitHub Actions|GitLab|Bitbucket|Selenium|Terraform|Kubernetes|Firebase|Figma|Jira|Vite|Tailwind CSS)\b/gi;
@@ -59,7 +45,21 @@ function Resume() {
     }
 
     return Array.from(skillSet);
-  };
+  }, []);
+
+  useEffect(() => {
+    const sortedExperiences = [...experiencesData.experience_list].sort(
+      (a, b) => {
+        const aDate = a.start_year * 12 + a.start_month;
+        const bDate = b.start_year * 12 + b.start_month;
+        return bDate - aDate;
+      }
+    );
+
+    setExperiences(sortedExperiences);
+    setSkills(extractSkills(sortedExperiences));
+    setLoading(false);
+  }, [extractSkills]);
 
   const formatDate = (
     year: number,
@@ -124,11 +124,11 @@ function Resume() {
         <div className="container mx-auto flex justify-between items-center">
           <Link
             to="/"
-            className="text-xl font-bold hover:text-purple-400 transition-colors flex items-center gap-2"
+            className="text-lg font-bold hover:text-purple-400 transition-colors flex items-center gap-2"
           >
             <span>←</span> Back to Home
           </Link>
-          <h1 className="text-2xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+          <h1 className="text-xl font-bold bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
             Resume
           </h1>
         </div>
@@ -137,19 +137,19 @@ function Resume() {
       <main className="container mx-auto px-4 py-12 flex-grow">
         <div className="max-w-5xl mx-auto">
           <header className="mb-12 text-center">
-            <h1 className="text-5xl md:text-6xl font-bold text-white mb-4 animate-fade-in">
+            <h1 className="text-3xl md:text-4xl font-bold text-white mb-4 animate-fade-in">
               tkt
             </h1>
-            <p className="text-2xl text-purple-300 animate-fade-in animation-delay-100">
+            <p className="text-xl text-purple-300 animate-fade-in animation-delay-100">
               Web Application Developer
             </p>
-            <p className="text-lg text-slate-400 mt-2 animate-fade-in animation-delay-200">
+            <p className="text-base text-slate-400 mt-2 animate-fade-in animation-delay-200">
               Japan 🇯🇵
             </p>
           </header>
 
           <section className="mb-12">
-            <h2 className="text-3xl font-bold mb-8 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            <h2 className="text-2xl font-bold mb-8 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
               Professional Experience
             </h2>
 
@@ -179,10 +179,10 @@ function Resume() {
                       >
                         <div className="flex flex-col md:flex-row md:justify-between mb-4">
                           <div>
-                            <h3 className="text-xl font-bold text-white">
+                            <h3 className="text-lg font-bold text-white">
                               {exp.position_name}
                             </h3>
-                            <p className="text-lg text-purple-300">
+                            <p className="text-base text-purple-300">
                               {exp.organization_name}
                               {exp.is_client_work &&
                                 exp.client_company_name && (
@@ -225,7 +225,7 @@ function Resume() {
           </section>
 
           <section className="mb-12">
-            <h2 className="text-3xl font-bold mb-6 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
+            <h2 className="text-2xl font-bold mb-6 bg-gradient-to-r from-purple-400 to-pink-400 bg-clip-text text-transparent">
               Skills & Technologies
             </h2>
             <div className="flex flex-wrap gap-3">


### PR DESCRIPTION
大きすぎるフォントサイズを全体的に小さくしてバランスよく調整しました。

## 主な変更点
- Home.tsx: メインタイトルのtext-6xl→text-4xlに変更
- サブタイトル・見出しのtext-3xl→text-xlに変更
- Resume.tsx: 各フォントサイズを1段階ずつ小さく調整
- React Hookの警告修正

Fixes #623

Generated with [Claude Code](https://claude.ai/code)