### PR TITLE
fix: GitHub Pages SPAルーティング対応 - /resume直接アクセス時の404エラーを修正

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,14 +12,22 @@
     <script>
       // Handle redirect from 404.html for GitHub Pages SPA
       (function() {
-        var l = window.location;
-        if (l.search[1] === '/') {
-          var decoded = l.search.slice(1).split('&').map(function(s) { 
-            return s.replace(/~and~/g, '&')
-          }).join('?');
-          window.history.replaceState(null, null,
-              l.pathname.slice(0, -1) + decoded + l.hash
-          );
+        try {
+          var l = window.location;
+          if (l.search[1] === '/') {
+            var decoded = l.search.slice(1).split('&').map(function(s) { 
+              return s.replace(/~and~/g, '&')
+            }).join('?');
+            
+            // Validate decoded URL format before applying
+            var newPath = l.pathname.slice(0, -1) + decoded + l.hash;
+            if (newPath && newPath.length > 0) {
+              window.history.replaceState(null, null, newPath);
+            }
+          }
+        } catch (e) {
+          // Silently fail if URL decoding fails - let React Router handle the original URL
+          console.warn('SPA redirect failed:', e);
         }
       })();
     </script>

--- a/index.html
+++ b/index.html
@@ -12,11 +12,14 @@
     <script>
       // Handle redirect from 404.html for GitHub Pages SPA
       (function() {
-        const redirect = new URLSearchParams(window.location.search).get('redirect');
-        if (redirect) {
-          // Remove the redirect query parameter and navigate to the actual path
-          const url = decodeURIComponent(redirect);
-          window.history.replaceState(null, '', '/' + url);
+        var l = window.location;
+        if (l.search[1] === '/') {
+          var decoded = l.search.slice(1).split('&').map(function(s) { 
+            return s.replace(/~and~/g, '&')
+          }).join('?');
+          window.history.replaceState(null, null,
+              l.pathname.slice(0, -1) + decoded + l.hash
+          );
         }
       })();
     </script>

--- a/public/404.html
+++ b/public/404.html
@@ -1,9 +1,22 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>404 - Page Not Found</title>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <script type="text/javascript">
+      // GitHub Pages SPA redirect
+      // Store the current path and redirect to index.html
+      var segmentCount = 0;
+      var l = window.location;
+      l.replace(
+        l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
+        l.pathname.split('/').slice(0, 1 + segmentCount).join('/') + '/?/' +
+        l.pathname.slice(1).split('/').slice(segmentCount).join('/').replace(/&/g, '~and~') +
+        (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+        l.hash
+      );
+    </script>
 </head>
 <body>
-    <h1>404 - Page Not Found</h1>
 </body>
 </html>

--- a/public/404.html
+++ b/public/404.html
@@ -6,6 +6,7 @@
     <script type="text/javascript">
       // GitHub Pages SPA redirect
       // Store the current path and redirect to index.html
+      // segmentCount: Number of path segments to preserve (0 for root-level deployment)
       var segmentCount = 0;
       var l = window.location;
       l.replace(


### PR DESCRIPTION
GitHub PagesのSPAルーティング問題を修正しました。

## 変更内容
- 404.html: 直接アクセスされたURLを記録し、index.htmlにリダイレクト
- index.html: リダイレクトされたパスを復元し、React Routerに渡す

## 解決する問題
Closes #634

直接`/resume`にアクセスしたときの404エラーを修正しました。

Generated with [Claude Code](https://claude.ai/code)