### PR TITLE
feat: 全ページのPlaywrightテストを追加、/technologiesページの動作を検証

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       },
       "devDependencies": {
         "@biomejs/biome": "^2.1.4",
+        "@playwright/test": "^1.54.2",
         "@tktco/node-actionlint": "^1.6.0",
         "@types/http-server": "^0.12.4",
         "@types/node": "24.2.1",
@@ -1645,6 +1646,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protobufjs/aspromise": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.1.4",
+    "@playwright/test": "^1.54.2",
     "@tktco/node-actionlint": "^1.6.0",
     "@types/http-server": "^0.12.4",
     "@types/node": "24.2.1",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests",
+  timeout: 15 * 1000,
+  expect: {
+    timeout: 3000,
+  },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    actionTimeout: 0,
+    baseURL: "http://localhost:5173",
+    trace: "on-first-retry",
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+
+  webServer: {
+    command: "npm run dev",
+    port: 5173,
+    reuseExistingServer: true,
+    timeout: 30 * 1000,
+  },
+});

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -164,6 +164,15 @@ test.describe("Page Navigation", () => {
   test("should navigate between pages without errors", async ({
     page: playwright,
   }) => {
+    // エラーをキャッチするためのリスナーを設定（テスト全体で一度だけ設定）
+    const errors = [];
+
+    const errorHandler = (error) => {
+      errors.push(error);
+    };
+
+    playwright.on("pageerror", errorHandler);
+
     // ホームページから開始
     await playwright.goto("/");
 
@@ -179,18 +188,20 @@ test.describe("Page Navigation", () => {
         await linkElement.click();
         await playwright.waitForURL(`**${link.expectedPath}`);
 
-        // エラーがないかチェック
-        const errors = [];
-        playwright.on("pageerror", (error) => {
-          errors.push(error);
-        });
-
-        expect(errors).toHaveLength(0);
         console.log(`✅ Successfully navigated to ${link.expectedPath}`);
 
         // ホームに戻る
         await playwright.goto("/");
       }
     }
+
+    // エラーリスナーをクリーンアップ
+    playwright.off("pageerror", errorHandler);
+
+    // ナビゲーション中にエラーがないかチェック
+    expect(
+      errors,
+      `Navigation errors found: ${errors.map((e) => e.message).join(", ")}`
+    ).toHaveLength(0);
   });
 });

--- a/tests/pages.spec.js
+++ b/tests/pages.spec.js
@@ -1,0 +1,196 @@
+import { expect, test } from "@playwright/test";
+
+// テストするページのリスト
+const pages = [
+  { path: "/", name: "Home" },
+  { path: "/resume", name: "Resume" },
+  { path: "/technologies", name: "Technologies" },
+];
+
+// 各ページの基本テスト
+for (const page of pages) {
+  test.describe(`${page.name} Page`, () => {
+    test(`should load ${page.name} page without errors`, async ({
+      page: playwright,
+    }) => {
+      // エラーをキャッチするためのリスナーを設定
+      const errors = [];
+      const consoleErrors = [];
+
+      playwright.on("pageerror", (error) => {
+        errors.push(error);
+      });
+
+      playwright.on("console", (msg) => {
+        if (msg.type() === "error") {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      // ページにアクセス
+      const response = await playwright.goto(page.path);
+
+      // ページが正常にロードされたかチェック
+      expect(response.status()).toBe(200);
+
+      // ページタイトルが存在するかチェック
+      const title = await playwright.title();
+      expect(title).toBeTruthy();
+
+      // JavaScriptエラーがないかチェック
+      expect(
+        errors,
+        `JavaScript errors found on ${page.name} page: ${errors.map((e) => e.message).join(", ")}`
+      ).toHaveLength(0);
+
+      // 重大なコンソールエラーがないかチェック (ただし、一部の警告は除外)
+      const significantErrors = consoleErrors.filter(
+        (error) =>
+          !error.includes("Warning:") &&
+          !error.includes("DevTools") &&
+          !error.includes("chrome-extension:")
+      );
+      expect(
+        significantErrors,
+        `Console errors found on ${page.name} page: ${significantErrors.join(", ")}`
+      ).toHaveLength(0);
+
+      // ページの基本要素が表示されているかチェック
+      await expect(playwright.locator("body")).toBeVisible();
+
+      console.log(`✅ ${page.name} page (${page.path}) loaded successfully`);
+    });
+
+    test(`should not show "Load failed" error on ${page.name} page`, async ({
+      page: playwright,
+    }) => {
+      await playwright.goto(page.path);
+
+      // "Load failed"またはその他のエラーメッセージがないかチェック
+      const loadFailedText = await playwright
+        .locator("text=Load failed")
+        .count();
+      expect(
+        loadFailedText,
+        `"Load failed" error found on ${page.name} page`
+      ).toBe(0);
+
+      // エラーメッセージの一般的なパターンをチェック
+      const errorTexts = [
+        "エラー:",
+        "Error:",
+        "Failed to",
+        "読み込みに失敗",
+        "ネットワークエラー",
+        "不明なエラー",
+      ];
+
+      for (const errorText of errorTexts) {
+        const count = await playwright.locator(`text="${errorText}"`).count();
+        if (count > 0) {
+          console.warn(
+            `⚠️ Error text "${errorText}" found on ${page.name} page`
+          );
+        }
+      }
+    });
+
+    // Technologiesページの特別なテスト
+    if (page.path === "/technologies") {
+      test("should handle API failures gracefully on Technologies page", async ({
+        page: playwright,
+      }) => {
+        // ネットワークをブロックしてAPIエラーをシミュレート
+        await playwright.route(
+          "**/lapras.com/public/tktcorporation.json",
+          (route) => {
+            route.abort("failed");
+          }
+        );
+
+        await playwright.goto(page.path);
+
+        // エラーメッセージが適切に表示されるかチェック
+        await expect(playwright.locator('[role="alert"]')).toBeVisible({
+          timeout: 10000,
+        });
+
+        // 再試行ボタンが表示されるかチェック
+        await expect(
+          playwright.locator('button:has-text("再試行")')
+        ).toBeVisible();
+
+        console.log("✅ Technologies page handles API failures gracefully");
+      });
+
+      test("should show loading state on Technologies page", async ({
+        page: playwright,
+      }) => {
+        await playwright.goto(page.path);
+
+        // ローディングスピナーまたはテキストが表示されるかチェック（短時間）
+        const loadingSpinner = playwright.locator('[role="status"]');
+        const loadingText = playwright.locator('text="技術データを読み込み中"');
+        const loadingVisible =
+          (await loadingSpinner.isVisible()) || (await loadingText.isVisible());
+
+        // ローディング状態が確認できない場合でも、最終的にコンテンツが表示されればOK
+        if (!loadingVisible) {
+          console.log(
+            "Loading state not captured (too fast), checking final content..."
+          );
+        }
+
+        // 最終的にコンテンツまたはエラーメッセージが表示されるまで待機
+        await playwright.waitForFunction(
+          () => {
+            const loadingElement = document.querySelector('[role="status"]');
+            const errorElement = document.querySelector('[role="alert"]');
+            const contentElement = document.querySelector("section");
+
+            return !loadingElement || errorElement || contentElement;
+          },
+          { timeout: 15000 }
+        );
+
+        console.log("✅ Technologies page loading behavior verified");
+      });
+    }
+  });
+}
+
+// 全ページ共通のナビゲーションテスト
+test.describe("Page Navigation", () => {
+  test("should navigate between pages without errors", async ({
+    page: playwright,
+  }) => {
+    // ホームページから開始
+    await playwright.goto("/");
+
+    // 各ページへのナビゲーションをテスト
+    const links = [
+      { selector: 'a[href="/resume"]', expectedPath: "/resume" },
+      { selector: 'a[href="/technologies"]', expectedPath: "/technologies" },
+    ];
+
+    for (const link of links) {
+      const linkElement = playwright.locator(link.selector);
+      if ((await linkElement.count()) > 0) {
+        await linkElement.click();
+        await playwright.waitForURL(`**${link.expectedPath}`);
+
+        // エラーがないかチェック
+        const errors = [];
+        playwright.on("pageerror", (error) => {
+          errors.push(error);
+        });
+
+        expect(errors).toHaveLength(0);
+        console.log(`✅ Successfully navigated to ${link.expectedPath}`);
+
+        // ホームに戻る
+        await playwright.goto("/");
+      }
+    }
+  });
+});


### PR DESCRIPTION
## 概要

/technologiesページの「Load failed」エラーを調査し、全ページにPlaywrightテストを導入しました。

## 変更内容

- ✅ 全ページ（Home, Resume, Technologies）の包括的なPlaywrightテストを実装
- ✅ /technologiesページの動作検証 - 正常に動作していることを確認
- ✅ API失敗時のエラーハンドリングテスト
- ✅ ローディング状態の表示テスト
- ✅ ページ間ナビゲーションテスト

## 結論

元々報告されていた「Load failed」エラーは現在発生しておらず、すべてのページが正常に動作しています。

Resolves #638

🤖 Generated with [Claude Code](https://claude.ai/code)